### PR TITLE
Add support to hamachi device

### DIFF
--- a/device/hamachi.mk
+++ b/device/hamachi.mk
@@ -1,0 +1,21 @@
+# Copyright (C) 2012 Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Device specific configuration for hamachi
+
+RECOVERY_EXTERNAL_STORAGE := /sdcard
+
+SYSTEM_FS_TYPE        := yaffs2
+SYSTEM_PARTITION_TYPE := EMMC
+SYSTEM_LOCATION       := /dev/block/mtdblock1


### PR DESCRIPTION
There is a new device called hamachi which is needed to support. And clone the mk file from otoro but modify the system partition to mtdblock1.
